### PR TITLE
Strip '\x03' control character, invalid in XML

### DIFF
--- a/sources/Mansalva.glyphs
+++ b/sources/Mansalva.glyphs
@@ -78444,7 +78444,7 @@ nodes = (
 width = 672;
 }
 );
-metricLeft = "K";
+metricLeft = "K";
 metricRight = K;
 unicode = 975;
 },


### PR DESCRIPTION
Restores ability to convert .glyphs to UFO with fontmake, fixes https://github.com/googlefonts/fontmake/issues/938